### PR TITLE
[Intel GPU] Allow XPU backend in Depthwise_conv2d&3d operators

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -603,7 +603,7 @@ struct ConvParams {
   // nInputPlane and nInputPlane == nOutputPlane (the latter due to the lack of
   // a depthwise multiplier)
   bool is_depthwise(const at::Tensor& input, const at::Tensor& weight) const  {
-    return input.is_cuda() &&
+    return (input.is_cuda() || input.is_xpu()) &&
            !transposed &&
            (input.ndimension() == 4 || input.ndimension() == 5) &&
            at::symint::size<T>(input, 1) == groups &&
@@ -1219,6 +1219,12 @@ ConvBackend _select_conv_backend(
       return ConvBackend::Cudnn;
     } else if (params.use_miopen(input, weight, bias_sizes_opt.has_value())) {
       return ConvBackend::MiopenDepthwise;
+    } else if (params.use_mkldnn(input, weight)) {
+      if (params.transposed) {
+        return ConvBackend::MkldnnTranspose;
+      } else {
+        return ConvBackend::Mkldnn;
+      }
     } else {
       if (input.ndimension() == 4) {
         return ConvBackend::CudaDepthwise2d;


### PR DESCRIPTION
This modification is to support XPU kernels for depthwise_conv2d and depthwise_conv3d.
Currently, when running depthwise_conv on XPU devices, it is calculated with Mkldnn via the ConvBackend::Overrideable path.
After this modification, depthwise_conv will be calculated directly using XpuDepthwise3d when the Mkldnn backend is disabled.